### PR TITLE
Fix/gnomegames installer

### DIFF
--- a/packages/gnomegames/install.sh
+++ b/packages/gnomegames/install.sh
@@ -6,10 +6,11 @@ curl -L https://github.com/crazy-electron/GnomeGames4Kindle/releases/latest/down
 
 echo "Extracting package..."
 unzip -q "$TEMP_DIR/gnomegames.zip" -d "$TEMP_DIR"
-cp -r "$TEMP_DIR/gnomegames"/* /mnt/us/extensions"
+mkdir -p /mnt/us/extensions/gnomegames
+cp -r "$TEMP_DIR/gnomegames"/* /mnt/us/extensions/gnomegames
 
 echo "Installing to device..."
-cp "/mnt/us/extensions/shortcut_gnomechess.sh" "/mnt/us/documents"
+cp "/mnt/us/extensions/gnomegames/shortcut_gnomechess.sh" "/mnt/us/documents"
 
 rm -rf "$TEMP_DIR"
 

--- a/packages/gnomegames/install.sh
+++ b/packages/gnomegames/install.sh
@@ -11,6 +11,7 @@ cp -r "$TEMP_DIR/gnomegames"/* /mnt/us/extensions/gnomegames
 
 echo "Installing to device..."
 cp "/mnt/us/extensions/gnomegames/shortcut_gnomechess.sh" "/mnt/us/documents"
+cp "/mnt/us/extensions/gnomegames/shortcut_gnomine.sh" "/mnt/us/documents"
 
 rm -rf "$TEMP_DIR"
 

--- a/packages/gnomegames/uninstall.sh
+++ b/packages/gnomegames/uninstall.sh
@@ -2,5 +2,6 @@
 echo "Uninstalling gnomegames"
 
 rm -fr /mnt/us/extensions/gnomegames
+rm /mnt/us/documents/shortcut_gnomechess.sh
 
 echo "gnomegames package uninstalled successfully"

--- a/packages/gnomegames/uninstall.sh
+++ b/packages/gnomegames/uninstall.sh
@@ -3,5 +3,6 @@ echo "Uninstalling gnomegames"
 
 rm -fr /mnt/us/extensions/gnomegames
 rm /mnt/us/documents/shortcut_gnomechess.sh
+rm /mnt/us/documents/shortcut_gnomine.sh
 
 echo "gnomegames package uninstalled successfully"


### PR DESCRIPTION
- Fix gnomegames being installed directly to `/mnt/us/documents` instead of `/mnt/us/documents/gnomegames`
- Add shortcut to `gnomines` automatically 
- Fix shortcuts not being removed when uninstalled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Changed installation location for gnomegames to a dedicated subdirectory for improved organization.
  - Both chess and minesweeper shortcut scripts are now installed and properly removed during uninstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->