### PR TITLE
Fix typo in musl uninstall.kpm

### DIFF
--- a/packages/musl/uninstall.kpm
+++ b/packages/musl/uninstall.kpm
@@ -1,2 +1,2 @@
 #!/bin/sh
-rm /lin/ld-musl-armhf.so.1
+rm /lib/ld-musl-armhf.so.1


### PR DESCRIPTION
/lin does not exist, should instead be /lib